### PR TITLE
Prepare for v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# [0.1.8](https://github.com/WorksApplications/SudachiTra/releases/tag/v0.1.8) (2023-03-10)
+
+## Highlights
+
+- Add new `word_format_type`: `normalized_nouns`. (#48, #50)
+  - Normalizes morphemes that do not have conjugation form.
+
+## Other
+
+- Faster part-of-speech matching (#36)
+- Use HuggingFace compatible pretokenizer (#38)
+- Fix/Update pretraining scripts and documents (#39, #40, #45, #46)
+- Fix github test workflow (#49)
+- Enable to save vocab file with duplicated items (#54)


### PR DESCRIPTION
Merge commit of this PR will be tagged as v0.1.8.

- Changelog file is added (#56).
- chiTra version is managed only by github releases, thus we don't need to modify other files.